### PR TITLE
ci: group dependabot updates by semver level and skip npm majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,16 @@ updates:
       - 'derogab'
     labels:
       - 'dependencies'
+    groups:
+      github-actions-major:
+        update-types:
+          - 'major'
+      github-actions-minor:
+        update-types:
+          - 'minor'
+      github-actions-patch:
+        update-types:
+          - 'patch'
   
   # Maintain dependencies for Node NPM
   - package-ecosystem: 'npm'
@@ -27,3 +37,14 @@ updates:
       - 'derogab'
     labels:
       - 'dependencies'
+    groups:
+      npm-minor:
+        update-types:
+          - 'minor'
+      npm-patch:
+        update-types:
+          - 'patch'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'


### PR DESCRIPTION
## Summary
Group Dependabot updates by semantic version level to reduce pull request noise while keeping breaking npm upgrades manual.

## Changes
- Group GitHub Actions updates into separate major, minor, and patch pull requests.
- Group npm minor and patch updates into separate pull requests.
- Ignore npm major version updates.

## Test plan
- [x] Validate the Dependabot YAML structure.
- [x] Run `git diff --check`.
- [x] Run `npm run compile`.
- [ ] Confirm the next monthly Dependabot run creates the expected grouped updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups Dependabot updates by semver to cut PR noise and keep breaking `npm` upgrades manual. This makes maintenance quieter and reviews safer.

- **Dependencies**
  - Split GitHub Actions updates into separate major, minor, and patch PRs.
  - Group `npm` minor and patch updates; ignore `npm` majors.

<sup>Written for commit 7bc71c82a01137b8e04d745646c97bac6f3ad251. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/derogab/fake-me/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

